### PR TITLE
Error messages more explicit in alert dialogs

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ type CipherReturns = {
 
 function caesar(text: string, key: string, decrypt: boolean = false): CipherReturns | undefined {
     if (key === "") {
-        alert("Veuillez indiquer une clé valable")
+        alert("Veuillez indiquer une clé valable. Celle-ci doit être un nombre entier.")
         return undefined
     }
     text = normalize(text)
@@ -38,7 +38,7 @@ function caesar(text: string, key: string, decrypt: boolean = false): CipherRetu
 function vigenere(text: string, key: string, decrypt: boolean = false): CipherReturns | undefined {
     key = key.toUpperCase().replace(/[^A-Z]/g, "")
     if (key === "") {
-        alert("Veuillez indiquer une clé valable")
+        alert("Veuillez indiquer une clé valable. Celle-ci doit être un mot ou une suite de lettres.")
         return undefined
     }
 text = normalize(text)


### PR DESCRIPTION
Les messages affichés lorsque les clés saisies pour les chiffrements de César et de Vigenère sont invalides ont été modifiés : 
- On explicite le besoin d'avoir un nombre entier pour le chiffrement de César lorsque l'alerte est affichée.
- On explicite le besoin d'avoir un mot ou une chaîne de caractères pour le chiffrement de Vigenère lorsque l'alerte est affichée.